### PR TITLE
[유저인증] PrivateRoute 라우팅 버그 fix

### DIFF
--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -7,7 +7,8 @@ import { authStates } from '../libs/utils';
 
 const PrivateRoute = ({ redirectPath = '/login', children }) => {
   const userState = useSelector((state) => state.userAuth.state);
-
+  if (userState === authStates.INITIAL || userState === authStates.PENDING)
+    return null;
   if (userState !== authStates.AUTHORIZED)
     return <Navigate to={redirectPath} replace />;
 

--- a/src/libs/userAuth.helpers.js
+++ b/src/libs/userAuth.helpers.js
@@ -43,7 +43,7 @@ export const useAuth = () => {
     dispatch(setState(state));
     if (state === authStates.AUTHORIZED) {
       axios.defaults.headers.common.Authorization = `Bearer ${access}`;
-      //   const expireTime = new Date().getTime() + 2000;
+      // const expireTime = new Date().getTime() + 2000;
       const expireTime = new Date().getTime() + EXPIRE_TIME;
       const refreshInfo = { token: refresh, expireTime };
       localStorage.setItem('refreshInfo', JSON.stringify(refreshInfo));
@@ -78,7 +78,7 @@ export const useAuth = () => {
   // handlers
   const handleAuthState = () => {
     switch (userState) {
-      case authStates.UNAUTHORIZED: // initial state일 때, refresh 진행
+      case authStates.INITIAL: // initial state일 때, refresh 진행
         refresh();
         break;
       case authStates.PENDING: // 상태 변화가 발생하는 중

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -27,6 +27,7 @@ export const pushRecentSearch = (key, title, isLocation, data) => {
 };
 
 export const authStates = {
+  INITIAL: 'initial',
   UNAUTHORIZED: 'unAuthorized',
   AUTHORIZED: 'authorized',
   EXPIRED: 'expired',

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,23 +1,28 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
 import UserPageHeader from '../../components/UserPageHeader';
 import FindPasswordModal from './FindPasswordModal';
 import { useFindPasswordModal } from './login.helpers';
 import { LoginContainer } from './login.style';
 import LoginBody from './LoginBody';
 import LoginBottom from './LoginBottom';
+import { authStates } from '../../libs/utils';
 
 const Login = ({ login, refresh }) => {
   const { isFindPassword, openFindPassword, closeFindPassword } =
     useFindPasswordModal();
-
+  const authState = useSelector((state) => state.userAuth.state);
+  if (authState === authStates.AUTHORIZED) return <Navigate to={-1} replace />;
+  if (authState === authStates.PENDING) return null;
   return (
     <LoginContainer>
       {isFindPassword ? (
         <FindPasswordModal closeFindPassword={closeFindPassword} />
       ) : null}
       <UserPageHeader />
-      <LoginBody login={login} refresh={refresh} />
+      <LoginBody authState={authState} login={login} refresh={refresh} />
       <LoginBottom openFindPassword={openFindPassword} />
     </LoginContainer>
   );

--- a/src/pages/Login/LoginBody.jsx
+++ b/src/pages/Login/LoginBody.jsx
@@ -1,23 +1,14 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import { LoginBodyContainer } from './login.style';
 import jmcIcon from '../../assets/img/user-jmc-icon.svg';
 import { useLoginHandler } from './login.helpers';
 import LoginError from './LoginError';
 import { authStates } from '../../libs/utils';
 
-const LoginBody = ({ login, refresh }) => {
+const LoginBody = ({ authState, login, refresh }) => {
   const { handleEmailChange, handlePasswordChange, handleLogin } =
     useLoginHandler(login, refresh);
-
-  const navigate = useNavigate();
-  const authState = useSelector((state) => state.userAuth.state);
-
-  useEffect(() => {
-    if (authState === authStates.AUTHORIZED) navigate(-1);
-  });
 
   return (
     <LoginBodyContainer>

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -47,13 +47,13 @@ const MyPage = () => {
           </div>
           <div className="myPageBtn">
             <div className="count">1</div>
-            심사중인
+            추가한
             <br />
             맛집
           </div>
           <div className="myPageBtn">
             <div className="count">1</div>
-            심사중인
+            찜한
             <br />
             맛집
           </div>
@@ -76,7 +76,9 @@ const MyPage = () => {
             <div className="categorySubTitle">위치</div>
             <div className="categories">
               {locCats.map((loc) => (
-                <div className="category">{loc}</div>
+                <div key={loc} className="category">
+                  {loc}
+                </div>
               ))}
             </div>
             <button type="button" className="changeBtn">
@@ -92,7 +94,9 @@ const MyPage = () => {
             <div className="categorySubTitle">음식 종류</div>
             <div className="categories">
               {foodCats.map((food) => (
-                <div className="category">{food}</div>
+                <div key={food} className="category">
+                  {food}
+                </div>
               ))}
             </div>
             <button type="button" className="changeBtn">

--- a/src/redux/userAuth.js
+++ b/src/redux/userAuth.js
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { authStates } from '../libs/utils';
 
 const initialState = {
-  state: authStates.UNAUTHORIZED,
+  state: authStates.INITIAL,
   accessToken: null,
   refreshToken: null,
   expireTime: null,
@@ -15,6 +15,9 @@ export const userAuthSlice = createSlice({
   reducers: {
     setState: (state, action) => {
       switch (action.payload) {
+        case authStates.INITIAL:
+          state.state = authStates.INITIAL;
+          break;
         case authStates.AUTHORIZED:
           state.state = authStates.AUTHORIZED;
           break;


### PR DESCRIPTION
## PR 요약

> 유저인증 state에 INITIAL을 추가하고, PrivateRoute의 인증 방식을 변경하였다.

## 변경된 점

> 앱에 유저가 최초로 진입할 때의 state인 INITIAL을 추가하여, 첫 진입시의 상태를 구분하였고,
이를 통해 PrivateRoute가 url을 곧바로 login 페이지로 이동시키는 버그를 해결하였다.
그리고, 로그인 페이지에서 유저의 인증 상태를 확인하고 navigating 하는 부분을 상위 컴포넌트로 옮겼다.

## 이슈 번호

> #47
