### PR TITLE
[회원가입] 회원가입시 이메일 인증 구현

### DIFF
--- a/src/pages/Join/EmailValidationMessage.jsx
+++ b/src/pages/Join/EmailValidationMessage.jsx
@@ -1,0 +1,20 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+const EmailValidationMessage = ({ validationStatus }) => {
+  let message;
+
+  if (validationStatus === 'sent') {
+    message = '입력하신 이메일 주소로 인증번호가 발송되었습니다.';
+  } else if (validationStatus === 'success') {
+    message = '인증이 완료되었습니다.';
+  } else {
+    message = '인증번호를 다시 확인해주세요.';
+  }
+
+  return (
+    <div className={`validationMessage ${validationStatus}`}>{message}</div>
+  );
+};
+
+export default EmailValidationMessage;

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -28,6 +28,9 @@ const Join = () => {
     deleteCategory,
     goToNextStage,
     postJoinRequest,
+    emailValidationRequest,
+    varificationCode,
+    reset,
   } = useJoinHandler();
 
   return (
@@ -43,6 +46,9 @@ const Join = () => {
             return (
               <JoinBodyFirst
                 email={email}
+                emailValidationRequest={emailValidationRequest}
+                varificationCode={varificationCode}
+                codeReset={reset}
                 nickName={nickName}
                 password={password}
                 passwordConfirm={passwordConfirm}
@@ -68,12 +74,7 @@ const Join = () => {
             );
           case 3:
             return (
-              <JoinSuccess
-                nickName={nickName}
-                email={email}
-                status={status}
-                error={error}
-              />
+              <JoinSuccess nickName={nickName} status={status} error={error} />
             );
           default:
             return null;

--- a/src/pages/Join/JoinBodyFirst.jsx
+++ b/src/pages/Join/JoinBodyFirst.jsx
@@ -1,11 +1,15 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useInputValidation, useWarningHandler } from './join.helpers';
 import { JoinBodyFirstContainer } from './join.style';
 import JoinWarningMessage from './JoinWarningMessage';
+import EmailValidationMessage from './EmailValidationMessage';
 
 const JoinBodyFirst = ({
   email,
+  emailValidationRequest,
+  varificationCode,
+  codeReset,
   nickName,
   password,
   passwordConfirm,
@@ -34,18 +38,101 @@ const JoinBodyFirst = ({
     checkAllForFirst,
   } = useInputValidation();
 
+  const [isValidation, setIsValidation] = useState(false);
+  const [validationStatus, setValidationStatus] = useState('sent');
+  const [isEmailChanged, setIsEmailChanged] = useState(false);
+  const [notValidatedError, setNotValidatedError] = useState(false);
+  useEffect(() => {
+    if (validationStatus === 'success') {
+      setNotValidatedError(false);
+    }
+  }, [validationStatus, setNotValidatedError]);
+
+  const codeRef = useRef();
+
   return (
     <JoinBodyFirstContainer>
-      <div className="label emailLabel">이메일</div>
-      <input
-        type="text"
-        className="input"
-        placeholder="example@example.com"
-        onChange={handleEmailChange}
-        onBlur={(event) => {
-          setEmailWarning(!checkEmail(event.target.value));
-        }}
-      />
+      <div className="label emailLabel">
+        이메일{' '}
+        {notValidatedError && (
+          <span
+            className=""
+            style={{ color: 'rgb(202, 45, 24)', fontSize: '12px' }}
+          >
+            ⚠️ 이메일 인증을 완료해주세요.
+          </span>
+        )}
+      </div>
+      <div className="email emailOuter">
+        <input
+          type="text"
+          className="input emailInput"
+          placeholder="example@example.com"
+          onChange={(e) => {
+            handleEmailChange(e);
+            setIsValidation(false);
+            setIsEmailChanged(true);
+          }}
+          onBlur={(event) => {
+            setEmailWarning(!checkEmail(event.target.value));
+          }}
+        />
+        <button
+          type="button"
+          className="checkBtn"
+          onClick={() => {
+            if (email && !emailWarning && isEmailChanged) {
+              codeReset();
+              emailValidationRequest();
+              setValidationStatus('sent');
+              setIsValidation(true);
+              setIsEmailChanged(false);
+            }
+          }}
+        >
+          확인
+        </button>
+      </div>
+      {isValidation && (
+        <div className="validationOuter">
+          <div className="validation">
+            <input
+              type="text"
+              className="validationInput"
+              ref={codeRef}
+              disabled={validationStatus === 'success' && true}
+            />
+            <button
+              type="button"
+              className="validationBtn"
+              onClick={() => {
+                if (codeRef.current.value === varificationCode) {
+                  setValidationStatus('success');
+                } else {
+                  setValidationStatus('fail');
+                }
+              }}
+            >
+              인증
+            </button>
+            <button
+              type="button"
+              className="validationBtn againBtn"
+              onClick={() => {
+                if (email && !emailWarning) {
+                  codeReset();
+                  emailValidationRequest();
+                  setValidationStatus('sent');
+                }
+              }}
+            >
+              재전송
+            </button>
+          </div>
+          <EmailValidationMessage validationStatus={validationStatus} />
+        </div>
+      )}
+
       <JoinWarningMessage
         flag={emailWarning}
         message="이메일을 확인해주세요."
@@ -106,9 +193,12 @@ const JoinBodyFirst = ({
         type="button"
         className="nextStageBtn"
         onClick={() => {
-          if (checkAllForFirst(email, nickName, password, passwordConfirm))
-            goToNextStage();
-          else {
+          if (checkAllForFirst(email, nickName, password, passwordConfirm)) {
+            if (validationStatus === 'success') goToNextStage();
+            else {
+              setNotValidatedError(true);
+            }
+          } else {
             setEmailWarning(!checkEmail(email));
             setNickNameWarning(!checkNickName(nickName));
             setPasswordWarning(!checkPassword(password));

--- a/src/pages/Join/JoinSuccess.jsx
+++ b/src/pages/Join/JoinSuccess.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useCustomNavigate } from '../../libs/common.helpers';
 import { JoinSuccessContainer } from './join.style';
 
-const JoinSuccess = ({ nickName, email, status, error }) => {
+const JoinSuccess = ({ nickName, status, error }) => {
   const { goToHomePage } = useCustomNavigate(useNavigate());
 
   if (status === 'loading') return null;
@@ -19,10 +19,7 @@ const JoinSuccess = ({ nickName, email, status, error }) => {
         ) : (
           <>
             <span className="userName">{nickName}</span>님, 안녕하세요! <br />
-            회원가입이 성공적으로 완료 되었습니다. <br />
-            가입하신 이메일(<span className="email colored">{email}</span>)로
-            인증 메일을 발송했습니다. <br />
-            이메일 인증을 완료해야 비밀번호 찾기 기능을 이용하실 수 있습니다.
+            회원가입이 성공적으로 완료 되었습니다.
           </>
         )}
       </div>

--- a/src/pages/Join/join.helpers.jsx
+++ b/src/pages/Join/join.helpers.jsx
@@ -67,11 +67,22 @@ export const useJoinHandler = () => {
 
   const joinInfo = {
     email,
-    nickName,
+    nickname: nickName,
     password,
-    locations: locations.map((loc) => loc.data && loc.data.name),
-    foods: foods.map((fo) => fo.data && fo.data.name),
+    locationCategoryList: locations.map((loc) => loc.name),
+    foodCategoryList: foods.map((fo) => fo.name),
   };
+
+  const {
+    mutate: emailValidationRequest,
+    data: varificationCode,
+    reset,
+  } = useMutation(() =>
+    axios
+      .post(`${SERVER_URL}/email-verification/send-code?email=${email}`)
+      .then((res) => res.data)
+  );
+
   const {
     mutate: postJoinRequest,
     status,
@@ -138,6 +149,9 @@ export const useJoinHandler = () => {
     deleteCategory,
     goToNextStage,
     postJoinRequest,
+    emailValidationRequest,
+    varificationCode,
+    reset,
   };
 };
 

--- a/src/pages/Join/join.style.jsx
+++ b/src/pages/Join/join.style.jsx
@@ -46,6 +46,71 @@ export const JoinBodyFirstContainer = styled.div`
       color: #ff6020;
     }
   }
+  .email {
+    margin-top: 9px;
+    height: 40px;
+    display: flex;
+    .emailInput {
+      margin-top: 0;
+    }
+    .checkBtn {
+      margin-left: 5px;
+      width: 60px;
+      height: 100%;
+      background-color: #6ab2b2;
+      font-family: Pretendard-SemiBold;
+      color: white;
+      font-size: 15px;
+      border-radius: 3px;
+      padding: 5px 10px;
+    }
+  }
+  .validationOuter {
+    margin-top: 0;
+    padding-bottom: 15px;
+    height: 40px;
+    .validation {
+      display: flex;
+
+      .validationInput {
+        // width: 100%;
+        flex-grow: 2;
+        padding-top: 17px;
+        // padding-left: 20px;
+        height: 30px;
+        border: none;
+        border-bottom: 1px solid #e3e3e3;
+      }
+      .validationBtn {
+        margin-left: 10px;
+        margin-top: 17px;
+        width: 45px;
+        height: 30px;
+        background-color: #7a7a7a;
+        font-family: Pretendard-SemiBold;
+        color: white;
+        font-size: 13px;
+        border-radius: 3px;
+        padding: 5px 5px;
+      }
+      .againBtn {
+        margin-left: 5px;
+        background-color: black;
+      }
+    }
+    .validationMessage {
+      margin-top: 7px;
+      color: #7a7a7a;
+      font-size: 12px;
+    }
+    .success {
+      color: #4bb543;
+    }
+    .fail {
+      color: rgb(202, 45, 24);
+    }
+  }
+
   .input {
     box-sizing: border-box;
     width: 100%;
@@ -139,7 +204,7 @@ export const JoinBodySecondContainer = styled.div`
 `;
 
 export const JoinSuccessContainer = styled.div`
-  margin: 38px 36px 0 36px;
+  margin: 70px 36px 0 36px;
   .successContent {
     text-align: center;
     font-size: 16px;

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import UserPageHeader from '../../components/UserPageHeader';
 import { MyPageContainer } from './myPage.style';
 import userIcon from '../../assets/img/user-colored-icon.svg';
-import warningIcon from '../../assets/img/yellow-warning-icon.svg';
 import { useMyPage } from './myPage.helpers';
 import MyPageBodyTop from './MyPageBodyTop';
 import MyPageBodyBottom from './MyPageBodyBottom';
@@ -29,17 +28,6 @@ const MyPage = () => {
           마이페이지
         </div>
       </UserPageHeader>
-      {userInfo.verified ? null : (
-        <div className="notVerifiedWarning">
-          <img src={warningIcon} alt="" className="warningIcon" />
-          <div className="notVerifiedWarningComment">
-            유저 인증이 완료되지 않았습니다. <br />
-            {/* 이메일 미인증 유저는 비밀번호 찾기 기능을 이용하실 수 없습니다. */}
-            {/* <br /> */}
-            가입하신 이메일의 메일함을 확인하고 인증을 완료해주세요.
-          </div>
-        </div>
-      )}
       <MyPageBodyTop
         userInfo={userInfo}
         handleGotoOnClick={handleGotoOnClick}


### PR DESCRIPTION
## PR 요약

> 기존에는 회원가입을 하는 도중에는 이메일 인증을 진행하지 않았으나
가입한 이후에 인증을 유도하는 것보다 가입할 때 인증하도록 하는 것이
좀 더 자연스러울 것 같아 플로우를 변경하였다. 따라서, 회원가입 과정에
인증절차도 추가했다.
인증을 위해서는 인증용 input을 추가하고 이를 위한 fetching 로직과 화면 변화를 위한 여러 state를 추가해야 했다. 지금와서 느끼는거지만 비즈니스 로직들을 custom hook 형태로 분리한다고 무리하게 이것저것 custom hook에 넣다보니 코드가 매우매우 지저분하다. 추후에 refactoring이 필요할 것 같다.

## 변경된 점

> 마이페이지에서 인증정보를 check 하는 부분이 삭제되었고, 회원가입시 이메일인증하는 부분이 추가되었다.

## 이슈 번호

>
