### PR TITLE
[둘러보기] 맛집 리스트 Fetching 방식 변경

### DIFF
--- a/src/libs/common.helpers.jsx
+++ b/src/libs/common.helpers.jsx
@@ -157,9 +157,11 @@ export const useInfiniteScroll = (data, getNextPage) => {
     }
   }, [inview]);
 
-  const ObserverDiv = <div ref={ref} className="observer" />;
+  // const ObserverDiv = () => {
+  //   return <div ref={ref} className="observer" />;
+  // };
 
-  return { ObserverDiv };
+  return { observerRef: ref };
 };
 
 export const useShare = (restaurant) => {

--- a/src/pages/Detail/DetailMenuPhotoModal.jsx
+++ b/src/pages/Detail/DetailMenuPhotoModal.jsx
@@ -6,6 +6,8 @@ import xIcon from '../../assets/img/x-icon.svg';
 import { useMenuPhoto } from './detail.helpers';
 import Loading from '../../components/Loading';
 import DetailMenuPhotoInnerModal from './DetailMenuPhotoInnerModal';
+import { useInfiniteScroll } from '../../libs/common.helpers';
+import { flattenPages } from '../../libs/utils';
 
 const DetailMenuPhotoModal = ({ closeMenuPhotoModal, menu }) => {
   const navigate = useNavigate();
@@ -17,6 +19,7 @@ const DetailMenuPhotoModal = ({ closeMenuPhotoModal, menu }) => {
     isPhotoDeleteModalOpen,
     setIsPhotoDeleteModalOpen,
     photos,
+    fetchNextPage,
     // isPhotosLoading,
     // photosError,
     // addMenuPhoto,
@@ -26,6 +29,7 @@ const DetailMenuPhotoModal = ({ closeMenuPhotoModal, menu }) => {
     handleAddMenuPhoto,
     openPhotoDeleteModal,
   } = useMenuPhoto(menu.id);
+  const { observerRef } = useInfiniteScroll(photos, fetchNextPage);
 
   return (
     <DetailMenuPhotoModalContainer>
@@ -41,23 +45,24 @@ const DetailMenuPhotoModal = ({ closeMenuPhotoModal, menu }) => {
           <div className="menuPhotoModalTitle">{menu.name}</div>
           <span className="menuModalPhotoPhotoNum">({menu.photoNum})</span>
         </div>
-        <ul className="menuPhotoModalUl">
-          {photos
-            ? photos.map((image) => (
-                <li key={image.id} className="menuPhotoModalLi">
-                  <img
-                    src={image.imageUrl}
-                    alt=""
-                    className="menuPhoto"
-                    onClick={() => {
-                      setSelectedPhoto(image);
-                    }}
-                    aria-hidden="true"
-                  />
-                </li>
-              ))
-            : null}
-        </ul>
+        {photos && (
+          <ul className="menuPhotoModalUl">
+            {flattenPages(photos.pages).map((image) => (
+              <li key={image.id} className="menuPhotoModalLi">
+                <img
+                  src={image.imageUrl}
+                  alt=""
+                  className="menuPhoto"
+                  onClick={() => {
+                    setSelectedPhoto(image);
+                  }}
+                  aria-hidden="true"
+                />
+              </li>
+            ))}
+            <div ref={observerRef} className="observer" />
+          </ul>
+        )}
         {isAuthorized() ? (
           <label
             className="newPhotoBtn"

--- a/src/pages/Detail/DetailReview.jsx
+++ b/src/pages/Detail/DetailReview.jsx
@@ -29,7 +29,7 @@ const DetailReview = ({ restaurantId, reviewNumber }) => {
   } = useReview(restaurantId);
   const navigate = useNavigate();
 
-  const { ObserverDiv } = useInfiniteScroll(reviewList, fetchNextPage);
+  const { observerRef } = useInfiniteScroll(reviewList, fetchNextPage);
 
   // if (reviewListIsFetching || reviewListError) return null;
 
@@ -76,7 +76,7 @@ const DetailReview = ({ restaurantId, reviewNumber }) => {
                 review={review}
               />
             ))}
-            {ObserverDiv}
+            <div ref={observerRef} className="observer" />
           </>
         ) : null}
       </ul>

--- a/src/pages/Detail/detail.helpers.jsx
+++ b/src/pages/Detail/detail.helpers.jsx
@@ -195,16 +195,62 @@ export const useMenuPhoto = (id) => {
 
   const { isAuthorized } = useAuth();
 
+  // const {
+  //   data: reviewList,
+  //   isFetching: reviewListIsFetching,
+  //   error: reviewListError,
+  //   hasNextPage,
+  //   fetchNextPage,
+  // } = useInfiniteQuery({
+  //   queryKey: ['reviewList', id, sort, order],
+  //   queryFn: async ({ queryKey, pageParam = 1 }) => {
+  //     const res = await axios.get(
+  //       url.concat(
+  //         `?page=${pageParam}&sort=${queryKey[2]}&order=${queryKey[3]}`
+  //       )
+  //     );
+  //     return {
+  //       data: res.data.data,
+  //       pageNum: pageParam,
+  //       isLast: pageParam === res.data.totalPages,
+  //       totalReviewCount: res.data.totalReviewCount,
+  //     };
+  //   },
+  //   getNextPageParam: (lastPage) => {
+  //     if (lastPage.isLast) return undefined;
+  //     return lastPage.pageNum + 1;
+  //   },
+  //   refetchOnWindowFocus: false,
+  // });
+
   const {
     data: photos,
-    isLoading: isPhotosLoading,
+    isFetching: isPhotosFetching,
     error: photosError,
-  } = useQuery(
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery(
     ['menuPhotos', id],
-    () => axios.get(url).then((res) => res.data),
+    ({ pageParam = 1 }) =>
+      axios.get(url.concat(`/?page=${pageParam}`)).then((res) => {
+        return {
+          data: res.data.data,
+          pageNum: pageParam,
+          isLast: pageParam >= res.data.totalPages,
+        };
+      }),
     {
+      getNextPageParam: (lastPage) => {
+        if (lastPage.isLast) return undefined;
+        return lastPage.pageNum + 1;
+      },
       refetchOnWindowFocus: false,
     }
+    //   getNextPageParam: (lastPage) => {
+    //   if (lastPage.isLast) return undefined;
+    //   return lastPage.pageNum + 1;
+    // },
+    //   refetchOnWindowFocus: false,
   );
 
   const { mutate: addMenuPhotoRequest, status: addMenuPhotoStatus } =
@@ -276,7 +322,9 @@ export const useMenuPhoto = (id) => {
     isPhotoDeleteModalOpen,
     setIsPhotoDeleteModalOpen,
     photos,
-    isPhotosLoading,
+    isPhotosFetching,
+    hasNextPage,
+    fetchNextPage,
     photosError,
     addMenuPhotoStatus,
     deleteMenuPhoto,
@@ -314,7 +362,7 @@ export const useReview = (id) => {
       return {
         data: res.data.data,
         pageNum: pageParam,
-        isLast: pageParam === res.data.totalPages,
+        isLast: pageParam >= res.data.totalPages,
         totalReviewCount: res.data.totalReviewCount,
       };
     },

--- a/src/pages/Judge/JudgeNew/JudgeSearchResult.jsx
+++ b/src/pages/Judge/JudgeNew/JudgeSearchResult.jsx
@@ -7,7 +7,7 @@ import { useInfiniteScroll } from '../../../libs/common.helpers';
 import JudgeSearchResultElem from './JudgeSearchResultElem';
 
 const JudgeSearchResult = ({ data, pagination, setMode, setSelected }) => {
-  const { ObserverDiv } = useInfiniteScroll(data.length, () => {
+  const { observerRef } = useInfiniteScroll(data.length, () => {
     if (pagination) pagination.nextPage();
   });
 
@@ -24,7 +24,7 @@ const JudgeSearchResult = ({ data, pagination, setMode, setSelected }) => {
               setSelected={setSelected}
             />
           ))}
-          {ObserverDiv}
+          <div ref={observerRef} className="observer" />
         </>
       ) : (
         <div className="noResult">

--- a/src/pages/MyPage/MyReview/MyReview.jsx
+++ b/src/pages/MyPage/MyReview/MyReview.jsx
@@ -19,7 +19,7 @@ const MyReview = () => {
     // hasNextPage,
     fetchNextPage,
   } = useMyReview();
-  const { ObserverDiv } = useInfiniteScroll(myReviews, fetchNextPage);
+  const { observerRef } = useInfiniteScroll(myReviews, fetchNextPage);
 
   return (
     <MyReviewContainer>
@@ -41,7 +41,7 @@ const MyReview = () => {
             {flattenPages(myReviews.pages).map((review) => (
               <MyReviewElem key={review.reviewId} review={review} />
             ))}
-            {ObserverDiv}
+            <div ref={observerRef} className="observer" />
           </>
         ) : null}
       </MyReviewUl>

--- a/src/pages/MyPage/ParticipatingRestaurant/ParticipatingRestaurantElem.jsx
+++ b/src/pages/MyPage/ParticipatingRestaurant/ParticipatingRestaurantElem.jsx
@@ -36,28 +36,6 @@ const ParticipatingRestaurantElem = ({ restaurant }) => {
         <img src={reviewIcon} alt="" className="reviewIcon" />
         <div className="reviewNum">{convertNum(4712)}</div>
       </div>
-      {/* <div className="wishAndRoulette">
-        <button
-          className={isWish ? 'colored' : null}
-          type="button"
-          onClick={(event) => {
-            pushWish();
-            event.stopPropagation();
-          }}
-        >
-          <img src={isWish ? coloredWishIcon : wishIcon} alt="" />
-        </button>
-        <button
-          className={isInRoulette ? 'colored' : null}
-          type="button"
-          onClick={(event) => {
-            pushRoulette(restaurant);
-            event.stopPropagation();
-          }}
-        >
-          <img src={isInRoulette ? coloredRouletteIcon : rouletteIcon} alt="" />
-        </button>
-      </div> */}
     </ParticipatingRestaurantLi>
   );
 };

--- a/src/pages/MyPage/ParticipatingRestaurant/participatingRestaurant.style.jsx
+++ b/src/pages/MyPage/ParticipatingRestaurant/participatingRestaurant.style.jsx
@@ -110,13 +110,13 @@ export const ParticipatingRestaurantLi = styled.li`
     flex-direction: column;
     align-items: center;
     margin-right: 10px;
-    margin-top: 5px;
+    margin-top: 10px;
     .reviewIcon {
-      width: 25px;
+      width: 15px;
       margin-bottom: 3px;
     }
     .reviewNum {
-      font-size: 13px;
+      font-size: 10px;
     }
   }
   .wishAndRoulette {

--- a/src/pages/MyPage/WishList/WishList.jsx
+++ b/src/pages/MyPage/WishList/WishList.jsx
@@ -12,7 +12,6 @@ const WishList = () => {
     // wishlistError,
     // hasNextPage,
     fetchNextPage,
-    flattenPages,
   } = useWishlist();
 
   return (
@@ -33,7 +32,7 @@ const WishList = () => {
       </WishListHeader>
       {wishlist ? (
         <List
-          restaurants={flattenPages(wishlist.pages)}
+          restaurants={wishlist}
           handlePageNum={fetchNextPage}
           className="myRestaurantList"
         />

--- a/src/pages/MyPage/myPage.helpers.jsx
+++ b/src/pages/MyPage/myPage.helpers.jsx
@@ -113,7 +113,7 @@ export const useWishlist = () => {
           return {
             data: res.data.data,
             pageNum: pageParam,
-            isLast: pageParam === res.data.totalPages,
+            isLast: pageParam >= res.data.totalPages,
           };
         }),
     getNextPageParam: (lastPage) => {
@@ -155,7 +155,7 @@ export const useParticipatingRestaurant = () => {
           return {
             data: res.data.data,
             pageNum: pageParam,
-            isLast: pageParam === res.data.totalPages,
+            isLast: pageParam >= res.data.totalPages,
           };
         }),
     getNextPageParam: (lastPage) => {
@@ -184,7 +184,7 @@ export const useParticipatingRestaurant = () => {
           return {
             data: res.data.data,
             pageNum: pageParam,
-            isLast: pageParam === res.data.totalPages,
+            isLast: pageParam >= res.data.totalPages,
           };
         }),
     getNextPageParam: (lastPage) => {
@@ -230,7 +230,7 @@ export const useMyReview = () => {
           return {
             data: res.data.data,
             pageNum: pageParam,
-            isLast: pageParam === res.data.totalPages,
+            isLast: pageParam >= res.data.totalPages,
           };
         }),
     getNextPageParam: (lastPage) => {

--- a/src/pages/Restaurant/List.jsx
+++ b/src/pages/Restaurant/List.jsx
@@ -4,19 +4,20 @@ import { ListUl, ListContainer } from './restaurant.style';
 
 import ListElem from './ListElem';
 import { useInfiniteScroll } from '../../libs/common.helpers';
+import { flattenPages } from '../../libs/utils';
 
 const List = ({ restaurants, handlePageNum, className }) => {
-  const { ObserverDiv } = useInfiniteScroll(restaurants, handlePageNum);
+  const { observerRef } = useInfiniteScroll(restaurants, handlePageNum);
 
   return (
     <ListContainer className={className}>
       <ListUl>
         {restaurants ? (
           <>
-            {restaurants.map((restaurant) => (
+            {flattenPages(restaurants.pages).map((restaurant) => (
               <ListElem key={restaurant.id} restaurant={restaurant} />
             ))}
-            {ObserverDiv}
+            <div ref={observerRef} className="observer" />
           </>
         ) : null}
       </ListUl>

--- a/src/pages/Restaurant/Map.jsx
+++ b/src/pages/Restaurant/Map.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { MapContainer } from './restaurant.style';
 import MapMarkerContainer from './MapMarkerContainer';
 import { setSelectedMarker } from '../../redux/map';
+import { flattenPages } from '../../libs/utils';
 
 // 상위 컴포넌트에서 데이터를 넘겨받는다.
 const Map = ({ restaurants }) => {
@@ -25,7 +26,7 @@ const Map = ({ restaurants }) => {
       >
         <MarkerClusterer averageCenter minLevel={5}>
           {restaurants
-            ? restaurants.map((restaurant) => {
+            ? flattenPages(restaurants.pages).map((restaurant) => {
                 const position = {
                   lat: restaurant.latitude,
                   lng: restaurant.longitude,

--- a/src/pages/Restaurant/Restaurant.jsx
+++ b/src/pages/Restaurant/Restaurant.jsx
@@ -12,13 +12,14 @@ const Restaurant = () => {
     locTag,
     foodCategory,
     recomCategory,
+    restaurants,
     // restaurantIsFetching,
     // restaurantIsError,
     categoryIsFetching,
     categoryIsError,
     // hasNextPage,
     fetchNextPage,
-    getRestaurantData,
+    // getRestaurantData,
   } = useRestaurant();
 
   const isMap = useSelector((state) => state.map.isMap);
@@ -37,9 +38,9 @@ const Restaurant = () => {
       )}
 
       {isMap ? (
-        <Map restaurants={getRestaurantData()} />
+        <Map restaurants={restaurants} />
       ) : (
-        <List restaurants={getRestaurantData()} handlePageNum={fetchNextPage} />
+        <List restaurants={restaurants} handlePageNum={fetchNextPage} />
       )}
     </RestaurantContainer>
   );


### PR DESCRIPTION
## PR 요약

> 처음 맛집 리스트 fetching을 구현할 때에는 useInfiniteQuery의 존재를 몰랐다. 따라서, query string 전달과 pagination을 위한 요청을 구분하여, 두 개의 요청을 보내도록 구현했다(노션에 정리해놓음). 상당히 비효율적인 방법이었고, 이후 useInfiniteQuery를 사용하게 되면서 refactoring 했어야 했는데, 까먹고 이제야 하게 되었다.
또한, 메뉴의 사진도 pagination 기능이 적용되도록 수정했다.
근데, querykey에 state를 전달하여 State가 변화하면 새로운 요청을 보내도록 하는 방식을 사용하면 스크롤이 맨 위로 올라가버리는 버그를 발견했다. 당장은 불편한 점이 없는데, flow가 조금 어색해지는 감이 있다.

## 변경된 점

> 맛집리스트 fetching 방식 변경, 메뉴 사진 pagination 도입

## 이슈 번호

> X
