### PR TITLE
[디테일] 메뉴 사진 썸네일 변경기능 추가

### DIFF
--- a/src/pages/Detail/DetailMenuElement.jsx
+++ b/src/pages/Detail/DetailMenuElement.jsx
@@ -40,6 +40,8 @@ const DetailMenuElement = ({ menu, useMenuElem }) => {
           deleteMenu={deleteMenu}
         />
       )}
+
+      {/* {true && ( */}
       {isMenuPhotoModalOpen && (
         <DetailMenuPhotoModal
           closeMenuPhotoModal={() => {

--- a/src/pages/Detail/DetailMenuFetchModal.jsx
+++ b/src/pages/Detail/DetailMenuFetchModal.jsx
@@ -79,6 +79,7 @@ const DetailMenuFetchModal = ({
             <input
               type="text"
               className="updateInput menuName"
+              maxLength={20}
               placeholder="메뉴 이름"
               defaultValue={menu && menu.name}
               onChange={(e) => {

--- a/src/pages/Detail/DetailMenuPhotoInnerModal.jsx
+++ b/src/pages/Detail/DetailMenuPhotoInnerModal.jsx
@@ -4,9 +4,11 @@ import { useSelector } from 'react-redux';
 import {
   DetailMenuPhotoInnerModalContainer,
   DetailMenuPhotoDeleteModalContainer,
+  ChangeThumbModalContainer,
 } from './detail.style';
 import xIcon from '../../assets/img/x-icon.svg';
 import trashIcon from '../../assets/img/colored-trashcan-icon.svg';
+import { useChnageThumbImage } from './detail.helpers';
 
 const DetailMenuPhotoInnerModal = ({
   isPhotoDeleteModalOpen,
@@ -17,9 +19,44 @@ const DetailMenuPhotoInnerModal = ({
   closePhotoDeleteModal,
 }) => {
   const userId = useSelector((state) => state.userAuth.id);
+
+  const {
+    isChangeModalOpen,
+    setIsChangeModalOpen,
+    changeThumbRequest,
+    handleClickChangeThumbBtn,
+  } = useChnageThumbImage(selectedPhoto.id);
+
   return (
     <DetailMenuPhotoInnerModalContainer>
-      {isPhotoDeleteModalOpen ? (
+      {isChangeModalOpen && (
+        <ChangeThumbModalContainer>
+          <div className="modalInner">
+            <div className="changeTitle">
+              해당 사진을 대표 이미지로 설정하시겠습니까?
+            </div>
+            <div className="btnOuter">
+              <button
+                type="button"
+                className="changeInnerBtn"
+                onClick={changeThumbRequest}
+              >
+                확인
+              </button>
+              <button
+                type="button"
+                className="changeInnerBtn"
+                onClick={() => {
+                  setIsChangeModalOpen(false);
+                }}
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </ChangeThumbModalContainer>
+      )}
+      {isPhotoDeleteModalOpen && (
         <DetailMenuPhotoDeleteModalContainer>
           <div className="modalInner">
             <div className="deleteTitle">해당 사진을 삭제하시겠습니까?</div>
@@ -44,7 +81,7 @@ const DetailMenuPhotoInnerModal = ({
             </div>
           </div>
         </DetailMenuPhotoDeleteModalContainer>
-      ) : null}
+      )}
       <div className="modalInner">
         <button
           className="closeBtn"
@@ -52,6 +89,13 @@ const DetailMenuPhotoInnerModal = ({
           onClick={closeMenuPhotoInnerModal}
         >
           <img src={xIcon} alt="" />
+        </button>
+        <button
+          type="button"
+          className="thumbBtn"
+          onClick={handleClickChangeThumbBtn}
+        >
+          대표이미지 지정
         </button>
         <img src={selectedPhoto.imageUrl} alt="" className="detailPhoto" />
         {/* <div className="fileName">{selectedPhoto.originalName}</div> */}

--- a/src/pages/Detail/DetailMenuPhotoModal.jsx
+++ b/src/pages/Detail/DetailMenuPhotoModal.jsx
@@ -43,7 +43,10 @@ const DetailMenuPhotoModal = ({ closeMenuPhotoModal, menu }) => {
         </button>
         <div className="menuPhotoModalTop">
           <div className="menuPhotoModalTitle">{menu.name}</div>
-          <span className="menuModalPhotoPhotoNum">({menu.photoNum})</span>
+          <div className="menuModalPhotoPhotoNum">[{menu.photoNum}]</div>
+          {/* <button type="button" className="changeThumbBtn">
+            대표 이미지 설정
+          </button> */}
         </div>
         {photos && (
           <ul className="menuPhotoModalUl">

--- a/src/pages/Detail/detail.helpers.jsx
+++ b/src/pages/Detail/detail.helpers.jsx
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   useInfiniteQuery,
   useMutation,
@@ -565,4 +566,41 @@ export const useDetailNav = () => {
   const [tab, setTab] = useState('main');
   const changeTab = (toChange) => setTab(toChange);
   return { tab, changeTab };
+};
+
+export const useChnageThumbImage = (id) => {
+  const accessToken = useSelector((state) => state.userAuth.accessToken);
+  const navigate = useNavigate();
+  const [isChangeModalOpen, setIsChangeModalOpen] = useState(false);
+  const { mutate: changeThumbRequest, status } = useMutation(
+    ['change-thumb'],
+    () =>
+      axios.post(
+        `${import.meta.env.VITE_API_BASE_URL}/menus/best?imageId=${id}`
+      ),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+  const handleClickChangeThumbBtn = () => {
+    if (accessToken) {
+      setIsChangeModalOpen(true);
+    } else {
+      navigate('/login');
+    }
+  };
+  useEffect(() => {
+    if (status === 'success') {
+      setIsChangeModalOpen(false);
+    }
+  }, [status]);
+
+  return {
+    isChangeModalOpen,
+    setIsChangeModalOpen,
+    changeThumbRequest,
+    handleClickChangeThumbBtn,
+  };
 };

--- a/src/pages/Detail/detail.style.jsx
+++ b/src/pages/Detail/detail.style.jsx
@@ -455,11 +455,20 @@ export const DetailMenuPhotoModalContainer = styled(ModalCommon)`
   }
   .menuPhotoModalTop {
     display: flex;
-    margin: 30px 0 22px 33px;
-    font-size: 20px;
+    align-items: center;
+    height: 22.5px;
+    margin: 20px 0 22px 33px;
+    font-size: 19px;
     font-family: Pretendard-Medium;
+    .menuPhotoModalTitle {
+      max-width: 200px;
+      white-space: nowrap;
+      overflow-x: auto;
+    }
     .menuModalPhotoPhotoNum {
-      margin-left: 5px;
+      height: 100%;
+      margin-left: 3px;
+      line-height: 22px;
       color: #6ab2b2;
     }
   }
@@ -522,8 +531,17 @@ export const DetailMenuPhotoInnerModalContainer = styled(ModalCommon)`
     align-items: center;
 
     color: #525252;
+    .thumbBtn {
+      margin-top: 15px;
+      background-color: #6ab2b2;
+      font-family: Pretendard-SemiBold;
+      font-size: 14px;
+      color: white;
+      border-radius: 10px;
+      padding: 5px 10px;
+    }
     .detailPhoto {
-      margin-top: 47px;
+      margin-top: 10px;
       width: 273px;
       height: 273px;
       border-radius: 3px;
@@ -1046,6 +1064,35 @@ export const DetailReviewElem = styled.li`
       .date {
         font-size: 13px;
         color: #bdbdbd;
+      }
+    }
+  }
+`;
+
+export const ChangeThumbModalContainer = styled(ModalCommon)`
+  .modalInner {
+    height: 110px;
+    width: 320px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 10px;
+    box-sizing: border-box;
+    .changeTitle {
+      font-family: Pretendard-SemiBold;
+      font-size: 16px;
+    }
+
+    .btnOuter {
+      display: flex;
+      .changeInnerBtn {
+        margin: 25px 5px 0 5px;
+        font-family: Pretendard-SemiBold;
+        background-color: #6a6a6a;
+        border-radius: 10px;
+        padding: 5px 10px;
+        color: white;
       }
     }
   }


### PR DESCRIPTION
## PR 요약

> 메뉴 사진들 중 썸네일 사진을 지정하면 홈의 세일 정보에
지정된 사진과 함께 Display된다. 현재는 썸네일 사진이 세일정보에만
사용이 되지만 추후에는 다양한 곳에서 사용될 수 있다. 따라서, 썸네일 사진을
변경할 수 있는 기능을 추가했다.

## 변경된 점

> 썸네일 변경 버튼 추가

## 이슈 번호

> X
